### PR TITLE
Cree profiles para adaptar a las necesidades de producción y de desarrollo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,8 @@ replay_pid*
 
 # Me olvide de agregar el .env
 .env
+.env.dev
+.env.prod
 .project
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - user_db
     environment:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka/
-      SPRING_DATASOURCE_URL: jdbc:postgresql://user_db:5432/ShopSwiftly
+      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     networks:

--- a/pom.xml
+++ b/pom.xml
@@ -48,5 +48,24 @@
         <!-- Agregar otros módulos aquí -->
     </modules>
 
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <spring.profiles.active>dev</spring.profiles.active>
+            </properties>
+            <!-- Other configuration specific to development -->
+        </profile>
+        <profile>
+            <id>prod</id>
+            <properties>
+                <spring.profiles.active>prod</spring.profiles.active>
+            </properties>
+            <!-- Other configuration specific to production -->
+        </profile>
+    </profiles>
     
 </project>

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -48,4 +48,4 @@ management:
 eureka:
   client:
     serviceUrl:
-      defaultZone: ${EUREKA_SERVER_URL:http://localhost:8761/eureka/} # Use the Docker Compose service name
+      defaultZone: ${EUREKA_SERVER_URL} # Use the Docker Compose service name

--- a/user-service/target/classes/application.yml
+++ b/user-service/target/classes/application.yml
@@ -48,4 +48,4 @@ management:
 eureka:
   client:
     serviceUrl:
-      defaultZone: ${EUREKA_SERVER_URL:http://localhost:8761/eureka/} # Use the Docker Compose service name
+      defaultZone: ${EUREKA_SERVER_URL} # Use the Docker Compose service name


### PR DESCRIPTION
En su ambiente de trabajo pueden crear dos .env
uno llamado .envdev y el otro env.prod 
cada uno contiene las variables de entorno dinamicas, y se seleccionan a través del comando cuando levantamos y probamos 

# How to run (dependiendo del profile) 
Desde el root (donde se encuentra el docker-compose 
-mvn clean package
-docker-compose --env-file .env.dev up 
Este comando corre el perfil de dev, todo localmente 
-docker-compose --env-file -env-prod up 
Este comando corre el perfil conectandose de manera remota a lo que ya esta levantado (Eureka y la Base de datos) 

Cada uno de ustedes debe crear los .env con lo siguiente
Este es un ejemplo de como se vería para levantarlo localmente
SPRING_PROFILES_ACTIVE =dev/prod (dependiendo de lo que esten creando) 
POSTGRES_USER = el usuario que tengan local 
POSTGRES_PASSWORD = el password que tengan en postgress para su usuario
POSTGRES_DB = el nombre de la base de datos (NO DEL SCHEMA)
SPRING_DATASOURCE_URL = este indica con jdbc:postgresql:// (los links internos que tengan) 